### PR TITLE
Support NumPy 2.0

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - main
 
 jobs:
   build_wheels:
@@ -12,18 +14,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: "pytest {project}/tests"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -36,7 +38,7 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -45,15 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     # upload to PyPI on every tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.10
+      - uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: pygeodesic-wheel-${{ matrix.os }}
 
   build_sdist:
     name: Build source distribution
@@ -41,6 +42,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
+          name: pygeodesic-sdist
 
   upload_pypi:
     needs: [build_wheels, build_sdist]
@@ -49,9 +51,12 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v4
-        with:
-          name: artifact
-          path: dist
+
+      - name: Flatten and move artifacts to dist
+        run: |
+          mkdir -p dist/
+          find . -name '*.whl' -exec mv {} dist/ \;
+          find . -name '*.tar.gz' -exec mv {} dist/ \;
 
       - uses: pypa/gh-action-pypi-publish@v1.8.11
         with:

--- a/pygeodesic/version.py
+++ b/pygeodesic/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 # Version
-__version__ = '0.1.9'
+__version__ = "0.1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = [
     "setuptools>=42",
     "wheel>=0.33.0",
-    "cython==3.0.5",
-    "oldest-supported-numpy"
+    "cython>=3.0.7",
+    "numpy>=2,<3",
 ]
 
 build-backend = "setuptools.build_meta"
@@ -18,11 +18,9 @@ filterwarnings = [
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only
-skip = "pp* *musllinux* cp36-* cp37-*" # disable PyPy and musl-based wheels
+skip = "pp* *musllinux* cp38-* cp313-*" # Build CPython 3.9-3.12
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.macos]
-# https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-archs = ["x86_64", "universal2"]
-test-skip = ["*_arm64", "*_universal2:arm64"]
+archs = ["native"]

--- a/setup.py
+++ b/setup.py
@@ -13,70 +13,92 @@ import sys
 # Get current path
 here = path.abspath(path.dirname(__file__))
 
+
 # Function to open the readme file
 def readme():
-    with open(path.join(here, 'README.md')) as f:
+    with open(path.join(here, "README.md")) as f:
         return f.read()
+
+
 long_description = readme()
-        
+
 # Find the version
-exec(open(path.join('pygeodesic','version.py')).read())
+exec(open(path.join("pygeodesic", "version.py")).read())
 
 try:
     from Cython.Distutils import build_ext
 except ImportError:
     from setuptools.command.build_ext import build_ext
+
     use_cython = False
 else:
     use_cython = True
+
 
 # Custom class to add required dependencies for building the project
 class build_ext_dependencies(build_ext):
     def finalize_options(self):
         build_ext.finalize_options(self)
         import numpy
+
         self.include_dirs.append(numpy.get_include())
         self.include_dirs.append("pygeodesic\geodesic_kirsanov")
 
-cmdclass    = { "build_ext": build_ext_dependencies }
+
+cmdclass = {"build_ext": build_ext_dependencies}
 ext_modules = []
-if use_cython:  
-    ext_modules += [ Extension("pygeodesic.geodesic", sources=["pygeodesic/geodesic.pyx",], language="c++")]
+if use_cython:
+    ext_modules += [
+        Extension(
+            "pygeodesic.geodesic",
+            sources=[
+                "pygeodesic/geodesic.pyx",
+            ],
+            language="c++",
+        )
+    ]
 else:
-    ext_modules += [ Extension("pygeodesic.geodesic", sources=["pygeodesic/geodesic.cpp",], language="c++")]
-    
+    ext_modules += [
+        Extension(
+            "pygeodesic.geodesic",
+            sources=[
+                "pygeodesic/geodesic.cpp",
+            ],
+            language="c++",
+        )
+    ]
+
 setup(
-    name = 'pygeodesic',
-    version = __version__,
-    description = 'Python library for calculating geodesic distance on triangular based surface meshes',
-    long_description = long_description,
-    long_description_content_type='text/markdown',
-    license = 'MIT license',
-    keywords = ["geodesic","distance","path","triangle","mesh","python","cython"],    
-    author = 'Michael Hogg',
-    author_email = 'michael.christopher.hogg@gmail.com',
-    url = "https://github.com/mhogg/pygeodesic",
-    download_url = "https://github.com/mhogg/pygeodesic/releases", 
-    packages = find_packages(),
-    include_package_data = True,
-    package_data = {'': ['README.md','LICENSE.txt'],
-                    'pygeodesic': ['Examples\*']},				
-    classifiers = [
+    name="pygeodesic",
+    version=__version__,
+    description="Python library for calculating geodesic distance on triangular based surface meshes",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    license="MIT license",
+    keywords=["geodesic", "distance", "path", "triangle", "mesh", "python", "cython"],
+    author="Michael Hogg",
+    author_email="michael.christopher.hogg@gmail.com",
+    url="https://github.com/mhogg/pygeodesic",
+    download_url="https://github.com/mhogg/pygeodesic/releases",
+    packages=find_packages(),
+    include_package_data=True,
+    package_data={"": ["README.md", "LICENSE.txt"], "pygeodesic": ["Examples\*"]},
+    classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python",                           
+        "Programming Language :: Python",
         "Programming Language :: Cython",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        ],
-    ext_modules = ext_modules,
-    cmdclass = cmdclass,
-    setup_requires = ["numpy"],
-    install_requires = ["numpy"],
+        "Programming Language :: Python :: 3.12",
+    ],
+    python_requires=">=3.9",
+    ext_modules=ext_modules,
+    cmdclass=cmdclass,
+    setup_requires=["numpy"],
+    install_requires=["numpy>=2,<3"],
 )


### PR DESCRIPTION
Add support for numpy 2.0 by building with 2.0. Bumps cibuildwheel and builds on native architecture for macOS for faster mac builds.

Also bumps to v0.1.10 in preparation for a release.
